### PR TITLE
Fix Docker build: include dev dependencies for esbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Copy package files
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci
 
 # Copy source files for asset building
 COPY build.js ./


### PR DESCRIPTION
## Problem

The Docker build was failing with "Error: Cannot find module 'esbuild'" because:
- esbuild is listed as a devDependency in package.json  
- Dockerfile was using "npm ci --only=production" which excludes dev dependencies
- But we need esbuild during the asset building stage

## Solution

Remove the "--only=production" flag from "npm ci" in the asset-builder stage so that dev dependencies (including esbuild) are installed.

## Test Plan

- [x] Docker build should now complete successfully
- [x] CI workflows should pass

This is a small, targeted fix for the Docker build issue identified after the main CI/CD PR was merged.

🤖 Generated with [Claude Code](https://claude.ai/code)