### PR TITLE
Fix Docker container permission denied error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,9 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates tzdata
 WORKDIR /root/
 
-# Copy the binary
+# Copy the binary and set execute permissions
 COPY --from=go-builder /app/passkey-auth .
+RUN chmod +x ./passkey-auth
 
 # Create non-root user
 RUN addgroup -g 1001 -S passkey && \


### PR DESCRIPTION
## Summary
- Add execute permissions to the passkey-auth binary after copying it to the final container stage
- Resolves the "permission denied" error when trying to run the Docker container

## Test plan
- [ ] Build the Docker image locally
- [ ] Run the container and verify it starts without permission errors
- [ ] Verify the application runs correctly inside the container

🤖 Generated with [Claude Code](https://claude.ai/code)